### PR TITLE
Minor updates to actually allow to get the output from the tool

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -7,7 +7,6 @@ http_archive(
     sha256 = "a4567ff02faca671b95e31d315bab18b42b6c6f1a60e91c6ea84e5a2142112c2",
     strip_prefix = "abseil-cpp-20211102.0",
     urls = [
-        "https://mirror.bazel.build/github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip",
         "https://github.com/abseil/abseil-cpp/archive/refs/tags/20211102.0.zip",
     ],
 )
@@ -28,7 +27,6 @@ http_archive(
     sha256 = "fb002599c6620611368933083b4cff031a32c8a98638877fe097f56142646ba9",
     strip_prefix = "re2-e8cb5ecb8ee1066611aa937a42fa10514edf30fb",
     urls = [
-        "https://mirror.bazel.build/github.com/google/re2/archive/e8cb5ecb8ee1066611aa937a42fa10514edf30fb.zip",
         "https://github.com/google/re2/archive/e8cb5ecb8ee1066611aa937a42fa10514edf30fb.zip",
     ],
 )
@@ -41,7 +39,6 @@ http_archive(
     strip_prefix = "protobuf-3.19.3",
     sha256 = "6b6bf5cd8d0cca442745c4c3c9f527c83ad6ef35a405f64db5215889ac779b42",
     urls = [
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.3.zip",
         "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.3.zip",
     ],
 )
@@ -51,7 +48,6 @@ http_archive(
     strip_prefix = "protobuf-3.19.3",
     sha256 = "6b6bf5cd8d0cca442745c4c3c9f527c83ad6ef35a405f64db5215889ac779b42",
     urls = [
-        "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.3.zip",
         "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v3.19.3.zip",
     ],
 )
@@ -61,7 +57,6 @@ http_archive(
     sha256 = "08f3b5c25eba2f7fb51db25692c2b9df6c557e0d8084bd8dc5e936d239f7641d",
     strip_prefix = "rules_cc-22532c537959149599e79df29808176345784cc1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_cc/archive/22532c537959149599e79df29808176345784cc1.tar.gz",
         "https://github.com/bazelbuild/rules_cc/archive/22532c537959149599e79df29808176345784cc1.tar.gz",
     ],
 )
@@ -72,7 +67,6 @@ http_archive(
     sha256 = "20b240eba17a36be4b0b22635aca63053913d5c1ee36e16be36499d167a2f533",
     strip_prefix = "rules_proto-11bf7c25e666dd7ddacbcd4d4c4a9de7a25175f8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/11bf7c25e666dd7ddacbcd4d4c4a9de7a25175f8.tar.gz",
         "https://github.com/bazelbuild/rules_proto/archive/11bf7c25e666dd7ddacbcd4d4c4a9de7a25175f8.tar.gz",
     ],
 )
@@ -82,7 +76,6 @@ http_archive(
     sha256 = "fc64d71583f383157e3e5317d24e789f942bc83c76fde7e5981cadc097a3c3cc",
     strip_prefix = "bazel-skylib-1.1.1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.zip",
         "https://github.com/bazelbuild/bazel-skylib/archive/refs/tags/1.1.1.zip",
     ],
 )
@@ -102,7 +95,6 @@ http_archive(
     sha256 = "c08d14e829bf5e2ab3bda2cc80a061126f2a430fcecdb9e9c0fc8023fd39d9a5",
     strip_prefix = "googletest-07f4869221012b16b7f9ee685d94856e1fc9f361",
     urls = [
-        "https://mirror.bazel.build/github.com/google/googletest/archive/07f4869221012b16b7f9ee685d94856e1fc9f361.tar.gz",
         "https://github.com/google/googletest/archive/07f4869221012b16b7f9ee685d94856e1fc9f361.tar.gz",
     ],
 )
@@ -115,7 +107,6 @@ http_archive(
     sha256 = "e7334dd254434c6668e33a54c8f839194c7c61840d52f4b6258eee28e9f3b20e",
     strip_prefix = "benchmark-1.1.0",
     urls = [
-        "https://mirror.bazel.build/github.com/google/benchmark/archive/v1.1.0.tar.gz",
         "https://github.com/google/benchmark/archive/v1.1.0.tar.gz",
     ],
 )
@@ -139,7 +130,6 @@ http_archive(
     sha256 = "466c36c6508a451734e4f4d76825cf9cd9b8716d2b70ef36479ae40f08271f88",
     strip_prefix = "gflags-2.2.0",
     urls = [
-        "https://mirror.bazel.build/github.com/gflags/gflags/archive/v2.2.0.tar.gz",
         "https://github.com/gflags/gflags/archive/v2.2.0.tar.gz",
     ],
 )
@@ -152,7 +142,6 @@ http_archive(
     sha256 = "7580e408a2c0b5a89ca214739978ce6ff480b5e7d8d7698a2aa92fadc484d1e0",
     strip_prefix = "glog-0.3.5",
     urls = [
-        "https://mirror.bazel.build/github.com/google/glog/archive/v0.3.5.tar.gz",
         "https://github.com/google/glog/archive/v0.3.5.tar.gz",
     ],
 )
@@ -187,7 +176,6 @@ http_archive(
     sha256 = "cdf0c2179ae7a7931dba52463741cf59024198bbf9673bf08415bcb46344110f",
     strip_prefix = "tinyxml2-6.2.0",
     urls = [
-        "https://mirror.bazel.build/github.com/leethomason/tinyxml2/archive/6.2.0.tar.gz",
         "https://github.com/leethomason/tinyxml2/archive/6.2.0.tar.gz",
     ],
 )
@@ -199,7 +187,6 @@ http_archive(
     sha256 = "d02fb68e1967fc3b8fed622755187a3df9cc175fe816cd149278d26b51519529",
     strip_prefix = "or-tools-53189020e3f995715a935aab7355357ce658fb76",
     urls = [
-        "https://mirror.bazel.build/github.com/google/or-tools/archive/53189020e3f995715a935aab7355357ce658fb76.tar.gz",
         "https://github.com/google/or-tools/archive/53189020e3f995715a935aab7355357ce658fb76.tar.gz",
     ],
 )
@@ -215,7 +202,6 @@ http_archive(
         # Please don't refactor out the SHA; if URLs aren't greppable,
         # we can't offer you an asynchronous mirroring service that
         # allows this huge archive to download in one second.
-        "https://mirror.bazel.build/github.com/llvm/llvm-project/archive/579c4921c0105698617cc1e1b86a9ecf3b4717ce.tar.gz",
         "https://github.com/llvm/llvm-project/archive/579c4921c0105698617cc1e1b86a9ecf3b4717ce.tar.gz",
     ],
 )
@@ -228,7 +214,6 @@ http_archive(
         # Please don't refactor out the SHA; if URLs aren't greppable,
         # we can't offer you an asynchronous mirroring service that
         # allows this huge archive to download in one second.
-        "https://mirror.bazel.build/github.com/llvm/llvm-project/archive/579c4921c0105698617cc1e1b86a9ecf3b4717ce.tar.gz",
         "https://github.com/llvm/llvm-project/archive/579c4921c0105698617cc1e1b86a9ecf3b4717ce.tar.gz",
     ],
 )
@@ -243,7 +228,6 @@ http_archive(
     build_file = "@or_tools_git//bazel:glpk.BUILD",
     sha256 = "9a5dab356268b4f177c33e00ddf8164496dc2434e83bd1114147024df983a3bb",
     urls = [
-        "https://mirror.bazel.build/ftp.gnu.org/gnu/glpk/glpk-4.52.tar.gz",
         "https://ftp.gnu.org/gnu/glpk/glpk-4.52.tar.gz",
     ],
 )

--- a/exegesis/itineraries/perf_subsystem.cc
+++ b/exegesis/itineraries/perf_subsystem.cc
@@ -205,7 +205,7 @@ PerfResult PerfSubsystem::ReadCounters() {
 
 ABSL_CONST_INIT absl::Mutex
     PerfSubsystem::ScopedLibPfmInitialization::  // NOLINT
-    refcount_mutex_;
+    refcount_mutex_(absl::kConstInit);
 int PerfSubsystem::ScopedLibPfmInitialization::refcount_ = 0;
 
 PerfSubsystem::ScopedLibPfmInitialization::ScopedLibPfmInitialization() {

--- a/exegesis/tools/README.md
+++ b/exegesis/tools/README.md
@@ -46,17 +46,6 @@ version you downloaded is unsupported.
 
 ### Usage
 
-To download and parse the most recent version of the SDM, run
-
-```shell
-bazel build -c opt //exegesis/data/x86:intel_instruction_sets.pbtxt
-```
-
-The parsed data will then be located in
-`bazel-genfiles/exegesis/data/x86/intel_instruction_sets.pbtxt`.
-
-#### Manual parsing
-
 The following command parses `/path/to/intel-sdm.pdf`, patches it to fix typos,
 extracts the instructions and removes mistakes and inconsistencies from the
 resulting database:


### PR DESCRIPTION
Probably shouldn't be merged as-is. These are just the changes I required to get the tool output (attached here: [intel_isa.zip](https://github.com/google/EXEgesis/files/8147004/intel_isa.zip))

My rough steps (on a clean ubuntu):

1. Install bazel
2. `sudo apt install build-essential zlib1g-dev`
3. Install `clang-13` (https://apt.llvm.org)
4. `export CC=clang-13`
5. `export CXX=clang++-13`
6. `bazel build ...`

Then to get the output:

```sh
bazel run -c opt //exegesis/tools:parse_intel_sdm -- \
  --exegesis_input_spec=/mnt/c/Users/Admin/Desktop/325462-sdm-vol-1-2abcd-3abcd-2021-12.pdf \
  --exegesis_output_file_base=/tmp/intel_isa \
  --exegesis_transforms=default
```